### PR TITLE
feat: change docker image base from nginx to caddy

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,14 @@ RUN corepack enable pnpm && \
     pnpm install && \
     pnpm run generate
 
-FROM nginxinc/nginx-unprivileged:stable-alpine-slim
-COPY --from=builder /data/.output/public /usr/share/nginx/html
-
+FROM caddy:alpine
+COPY --from=builder /data/.output/public /usr/share/caddy
+COPY <<"EOT" /etc/caddy/Caddyfile
+https:// {
+    file_server
+    root * /usr/share/caddy
+    tls internal {
+	    on_demand
+    }
+}
+EOT

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pnpm run generate
 
 1. Clone this repo
 2. Build: `docker build --tag localsend-web --file Containerfile`
-3. Run: `docker run --rm --publish 8080:8080 localsend-web`
+3. Run: `docker run --rm --publish 8080:443 --volume caddy-data:/data localsend-web`
 
 ## Contributing
 


### PR DESCRIPTION
Web Crypto API is available only in secure contexts (HTTPS). We need to deploy with HTTPS. So lets use caddy instead nginx.