### PR TITLE
feat(i18n): add Urdu (ur) language support

### DIFF
--- a/i18n/locales/ur.json
+++ b/i18n/locales/ur.json
@@ -1,0 +1,26 @@
+{
+  "index": {
+    "seo": {
+      "title": "LocalSend ویب",
+      "description": "اپنے براؤزر اور LocalSend چلانے والے دیگر آلات کے درمیان فائلیں شیئر کریں۔"
+    },
+    "connecting": "جوڑ رہا ہے...",
+    "webCryptoNotSupported": "آپ کا براؤزر LocalSend کو سپورٹ نہیں کرتا: Web Crypto API درکار ہے۔",
+    "empty": {
+      "title": "کسی اور آلے پر LocalSend کھولیں۔",
+      "deviceHint": "اس سائٹ کو کسی اور براؤزر یا نیٹو ورژن (v1.18.0 یا اس سے نئے) میں کھولیں۔",
+      "lanHint": "صرف ایک ہی نیٹ ورک میں موجود آلات دکھائے جاتے ہیں۔"
+    },
+    "you": "آپ ہیں:",
+    "pin": {
+      "label": "PIN: ",
+      "none": "کوئی نہیں"
+    },
+    "enterAlias": "نام درج کریں",
+    "enterPin": "PIN درج کریں",
+    "progress": {
+      "titleSending": "فائلیں بھیج رہا ہے...",
+      "titleReceiving": "فائلیں موصول ہو رہی ہیں..."
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -108,6 +108,13 @@ export default defineNuxtConfig({
         name: "Türkçe",
       },
       {
+        code: "ur",
+        language: "ur-PK",
+        file: "ur.json",
+        name: "اردو",
+        dir: "rtl",
+      },
+      {
         code: "zh-CN",
         language: "zh-CN",
         file: "zh-CN.json",


### PR DESCRIPTION
## Summary

Adds Urdu (`ur`) language support to the LocalSend Web App.

## Changes

### 1. New file: `i18n/locales/ur.json`
Complete Urdu translation of all strings in the web app, including:
- SEO title and description
- Connection status messages
- Empty state messages (device hint, LAN hint)
- User identity labels
- PIN labels
- Alias input placeholder
- File transfer progress messages

### 2. Modified: `nuxt.config.ts`
Registered the Urdu locale in the i18n configuration:
- Code: `ur`
- Language: `ur-PK`
- Name: `اردو`
- Direction: `rtl` (Right-to-Left)

## Notes
- Urdu is an RTL language, so `dir: "rtl"` has been specified in the locale config
- All strings from `en.json` have been translated
- JSON has been validated for correctness
