### PR TITLE
feat: add drag-and-drop, toast notifications, connection status, and …

### DIFF
--- a/app/components/Toast.vue
+++ b/app/components/Toast.vue
@@ -1,0 +1,51 @@
+<template>
+  <transition-group name="toast" tag="div" class="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+    <div
+      v-for="toast in store.toasts"
+      :key="toast.id"
+      class="flex items-center gap-2 px-4 py-3 rounded-lg shadow-lg min-w-[280px] max-w-sm"
+      :class="{
+        'bg-teal-600 text-white': toast.type === 'success',
+        'bg-red-600 text-white': toast.type === 'error',
+        'bg-gray-700 text-white': toast.type === 'info',
+      }"
+    >
+      <Icon
+        :name="toast.type === 'success'
+          ? 'material-symbols:check-circle'
+          : toast.type === 'error'
+            ? 'material-symbols:error'
+            : 'material-symbols:info'"
+        class="size-5 shrink-0"
+      />
+      <span class="flex-1 text-sm">{{ toast.message }}</span>
+      <button
+        class="shrink-0 opacity-70 hover:opacity-100"
+        @click="dismissToast(toast.id)"
+      >
+        <Icon name="material-symbols:close" class="size-4" />
+      </button>
+    </div>
+  </transition-group>
+</template>
+
+<script setup lang="ts">
+import { store, dismissToast } from "~/services/store";
+</script>
+
+<style scoped>
+.toast-enter-active {
+  transition: all 0.3s ease-out;
+}
+.toast-leave-active {
+  transition: all 0.2s ease-in;
+}
+.toast-enter-from {
+  opacity: 0;
+  transform: translateX(30px);
+}
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(30px);
+}
+</style>

--- a/app/components/dialog/Dialog.vue
+++ b/app/components/dialog/Dialog.vue
@@ -5,7 +5,7 @@
       class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
     >
       <div
-        class="bg-white w-full max-w-lg mx-4 rounded shadow-md text-black"
+        class="bg-white dark:bg-gray-800 w-full max-w-lg mx-4 rounded shadow-md text-black dark:text-white"
         role="dialog"
         aria-modal="true"
       >

--- a/app/components/dialog/InputDialog.vue
+++ b/app/components/dialog/InputDialog.vue
@@ -1,0 +1,74 @@
+<template>
+  <Dialog :visible="visible">
+    <div class="p-6">
+      <h2 class="text-lg font-bold mb-4">{{ title }}</h2>
+      <input
+        ref="inputRef"
+        v-model="inputValue"
+        type="text"
+        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+               bg-white dark:bg-gray-700 text-black dark:text-white
+               focus:outline-none focus:ring-2 focus:ring-teal-500"
+        :placeholder="placeholder"
+        @keyup.enter="confirm"
+      />
+      <div class="flex justify-end gap-2 mt-4">
+        <button
+          class="px-4 py-2 rounded-lg text-gray-600 dark:text-gray-300
+                 hover:bg-gray-100 dark:hover:bg-gray-700"
+          @click="cancel"
+        >
+          {{ cancelText }}
+        </button>
+        <button
+          class="px-4 py-2 rounded-lg bg-teal-600 text-white hover:bg-teal-500"
+          @click="confirm"
+        >
+          {{ confirmText }}
+        </button>
+      </div>
+    </div>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import Dialog from "~/components/dialog/Dialog.vue";
+
+const props = defineProps<{
+  visible: boolean;
+  title: string;
+  placeholder?: string;
+  defaultValue?: string;
+  confirmText?: string;
+  cancelText?: string;
+}>();
+
+const emit = defineEmits<{
+  confirm: [value: string];
+  cancel: [];
+}>();
+
+const inputValue = ref(props.defaultValue ?? "");
+const inputRef = ref<HTMLInputElement | null>(null);
+
+watch(
+  () => props.visible,
+  (val) => {
+    if (val) {
+      inputValue.value = props.defaultValue ?? "";
+      nextTick(() => {
+        inputRef.value?.focus();
+        inputRef.value?.select();
+      });
+    }
+  },
+);
+
+const confirm = () => {
+  emit("confirm", inputValue.value);
+};
+
+const cancel = () => {
+  emit("cancel");
+};
+</script>

--- a/app/components/dialog/SessionDialog.vue
+++ b/app/components/dialog/SessionDialog.vue
@@ -10,12 +10,12 @@
       </h1>
 
       <div class="flex">
-        <span class="flex-1 font-bold">Total:</span>
+        <span class="flex-1 font-bold">{{ t("index.progress.total") }}:</span>
         <span>{{ totalCurr }} / {{ totalTotal }}</span>
       </div>
       <ProgressBar :progress="store.session.curr / store.session.total" />
 
-      <p class="mt-4 font-bold">Files:</p>
+      <p class="mt-4 font-bold">{{ t("index.progress.files") }}:</p>
     </div>
 
     <div class="pl-4 pt-2 pr-4 max-h-[300px] overflow-y-auto">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,12 @@
 <template>
-  <div class="dark:text-white flex flex-col h-screen">
-    <div class="flex mt-2">
+  <div
+    class="dark:text-white flex flex-col h-screen"
+    @dragover.prevent="onDragOver"
+    @dragleave.prevent="onDragLeave"
+    @drop.prevent="onDrop"
+  >
+    <!-- Header -->
+    <div class="flex mt-2 items-center">
       <img
         src="/apple-touch-icon.png"
         alt="Logo"
@@ -11,13 +17,29 @@
         <h1 class="text-xl font-bold">LocalSend</h1>
         <h2 class="leading-none mt-0.5">Web</h2>
       </div>
+
+      <!-- Connection Status -->
+      <div class="ml-auto mr-4 flex items-center gap-2 text-sm">
+        <span
+          class="inline-block w-2.5 h-2.5 rounded-full"
+          :class="{
+            'bg-green-500': store.connectionStatus === 'connected',
+            'bg-yellow-500 animate-pulse': store.connectionStatus === 'reconnecting',
+            'bg-red-500': store.connectionStatus === 'disconnected',
+          }"
+        ></span>
+        <span class="hidden sm:inline opacity-70">
+          {{ t(`index.connection.${store.connectionStatus}`) }}
+        </span>
+      </div>
     </div>
 
+    <!-- Current User Info -->
     <div v-if="store.client" class="flex justify-center items-center mt-8 pb-8">
       <div class="flex">
         <div>
           {{ t("index.you") }}<br />
-          <span class="font-bold cursor-pointer" @click="updateAlias">{{
+          <span class="font-bold cursor-pointer" @click="showAliasDialog">{{
             store.client.alias
           }}</span>
         </div>
@@ -31,13 +53,14 @@
             {{ t("index.pin.label") }}
           </span>
           <br />
-          <span class="font-bold cursor-pointer" @click="updatePIN">
+          <span class="font-bold cursor-pointer" @click="showPinDialog">
             {{ store.pin ?? t("index.pin.none") }}
           </span>
         </div>
       </div>
     </div>
 
+    <!-- Connecting State -->
     <div
       v-if="!store.signaling"
       class="flex-1 flex flex-col items-center justify-center text-center px-2"
@@ -45,12 +68,15 @@
       <h3 v-if="minDelayFinished" class="text-3xl">
         {{
           webCryptoSupported
-            ? t("index.connecting")
+            ? store.connectionStatus === 'reconnecting'
+              ? t("index.connection.reconnecting")
+              : t("index.connecting")
             : t("index.webCryptoNotSupported")
         }}
       </h3>
     </div>
 
+    <!-- No Peers -->
     <div
       v-else-if="store.peers.length === 0"
       class="flex-1 flex flex-col items-center justify-center text-center px-2"
@@ -60,6 +86,7 @@
       <h3>{{ t("index.empty.lanHint") }}</h3>
     </div>
 
+    <!-- Peer List -->
     <div v-else class="flex justify-center px-4">
       <div class="w-96">
         <PeerCard
@@ -72,7 +99,58 @@
       </div>
     </div>
 
+    <!-- Drag & Drop Overlay -->
+    <transition name="fade">
+      <div
+        v-if="isDragging"
+        class="fixed inset-0 z-40 flex items-center justify-center bg-black bg-opacity-60 pointer-events-none"
+      >
+        <div class="text-center">
+          <Icon
+            name="material-symbols:cloud-upload"
+            class="size-20 text-teal-400 mb-4"
+          />
+          <p class="text-white text-2xl font-bold">
+            {{ t("index.dragDrop.hint") }}
+          </p>
+        </div>
+      </div>
+    </transition>
+
     <SessionDialog />
+    <Toast />
+
+    <!-- Alias Input Dialog -->
+    <InputDialog
+      :visible="aliasDialogVisible"
+      :title="t('index.enterAlias')"
+      :default-value="store.client?.alias ?? ''"
+      :confirm-text="t('index.dialog.confirm')"
+      :cancel-text="t('index.dialog.cancel')"
+      @confirm="onAliasConfirm"
+      @cancel="aliasDialogVisible = false"
+    />
+
+    <!-- PIN Input Dialog -->
+    <InputDialog
+      :visible="pinDialogVisible"
+      :title="t('index.enterPin')"
+      :default-value="store.pin ?? ''"
+      :confirm-text="t('index.dialog.confirm')"
+      :cancel-text="t('index.dialog.cancel')"
+      @confirm="onPinConfirm"
+      @cancel="pinDialogVisible = false"
+    />
+
+    <!-- PIN Prompt Dialog (for file transfer) -->
+    <InputDialog
+      :visible="transferPinDialogVisible"
+      :title="t('index.enterPin')"
+      :confirm-text="t('index.dialog.confirm')"
+      :cancel-text="t('index.dialog.cancel')"
+      @confirm="onTransferPinConfirm"
+      @cancel="onTransferPinCancel"
+    />
   </div>
 </template>
 
@@ -83,12 +161,16 @@ import {
   startSendSession,
   store,
   updateAliasState,
+  showToast,
+  requestNotificationPermission,
 } from "@/services/store";
 import { getAgentInfoString } from "~/utils/userAgent";
 import { protocolVersion } from "~/services/webrtc";
 import { generateRandomAlias } from "~/utils/alias";
 import { useFileDialog } from "@vueuse/core";
 import SessionDialog from "~/components/dialog/SessionDialog.vue";
+import InputDialog from "~/components/dialog/InputDialog.vue";
+import Toast from "~/components/Toast.vue";
 import {
   cryptoKeyToPem,
   generateClientTokenFromCurrentTimestamp,
@@ -108,25 +190,116 @@ const { t } = useI18n();
 
 const { open: openFileDialog, onChange } = useFileDialog();
 
+// --- Drag & Drop ---
+const isDragging = ref(false);
+let dragLeaveTimeout: ReturnType<typeof setTimeout> | null = null;
+
+const onDragOver = () => {
+  if (dragLeaveTimeout) clearTimeout(dragLeaveTimeout);
+  isDragging.value = true;
+};
+
+const onDragLeave = () => {
+  dragLeaveTimeout = setTimeout(() => {
+    isDragging.value = false;
+  }, 100);
+};
+
+const onDrop = async (e: DragEvent) => {
+  isDragging.value = false;
+  const files = e.dataTransfer?.files;
+  if (!files || files.length === 0) return;
+
+  if (!store.signaling) {
+    showToast(t("index.dragDrop.noPeer"), "error");
+    return;
+  }
+
+  if (store.peers.length === 0) {
+    showToast(t("index.dragDrop.noPeer"), "error");
+    return;
+  }
+
+  // Send to the first available peer
+  const peerId = store.peers[0].id;
+  await startSendSession({
+    files,
+    targetId: peerId,
+    onPin: requestTransferPin,
+  });
+};
+
+// --- Custom Input Dialogs ---
+const aliasDialogVisible = ref(false);
+const pinDialogVisible = ref(false);
+const transferPinDialogVisible = ref(false);
+let transferPinResolve: ((value: string | null) => void) | null = null;
+
+const showAliasDialog = () => {
+  aliasDialogVisible.value = true;
+};
+
+const onAliasConfirm = (value: string) => {
+  aliasDialogVisible.value = false;
+  if (!value || !store.signaling || !store.client) return;
+
+  store.signaling.send({
+    type: "UPDATE",
+    info: {
+      alias: value,
+      version: store.client.version,
+      deviceModel: store.client.deviceModel,
+      deviceType: store.client.deviceType,
+      token: store.client.token,
+    },
+  });
+
+  updateAliasState(value);
+};
+
+const showPinDialog = () => {
+  pinDialogVisible.value = true;
+};
+
+const onPinConfirm = (value: string) => {
+  pinDialogVisible.value = false;
+  store.pin = value ? value : null;
+};
+
+const requestTransferPin = (): Promise<string | null> => {
+  return new Promise((resolve) => {
+    transferPinResolve = resolve;
+    transferPinDialogVisible.value = true;
+  });
+};
+
+const onTransferPinConfirm = (value: string) => {
+  transferPinDialogVisible.value = false;
+  transferPinResolve?.(value || null);
+  transferPinResolve = null;
+};
+
+const onTransferPinCancel = () => {
+  transferPinDialogVisible.value = false;
+  transferPinResolve?.(null);
+  transferPinResolve = null;
+};
+
+// --- File Selection via Click ---
 onChange(async (files) => {
   if (!files) return;
-
   if (files.length === 0) return;
-
   if (!store.signaling) return;
 
   await startSendSession({
     files,
     targetId: targetId.value,
-    onPin: async () => {
-      return prompt(t("index.enterPin"));
-    },
+    onPin: requestTransferPin,
   });
 });
 
 const minDelayFinished = ref(false);
 const webCryptoSupported = ref(true);
-
 const targetId = ref("");
 
 const selectPeer = (id: string) => {
@@ -134,42 +307,12 @@ const selectPeer = (id: string) => {
   openFileDialog();
 };
 
-const updateAlias = async () => {
-  if (!store.client) return;
-
-  const current = store.client;
-  if (!current) return;
-
-  const alias = prompt(t("index.enterAlias"), current.alias);
-  if (!alias || !store.signaling) return;
-
-  store.signaling.send({
-    type: "UPDATE",
-    info: {
-      alias: alias,
-      version: current.version,
-      deviceModel: current.deviceModel,
-      deviceType: current.deviceType,
-      token: current.token,
-    },
-  });
-
-  updateAliasState(alias);
-};
-
-const updatePIN = async () => {
-  const pin = prompt(t("index.enterPin"));
-  if (typeof pin === "string") {
-    store.pin = pin ? pin : null;
-  }
-};
-
 onMounted(async () => {
   webCryptoSupported.value = isWebCryptoSupported();
 
+  requestNotificationPermission();
+
   setTimeout(() => {
-    // to prevent flickering during initial connection
-    // i.e. show blank screen instead of "Connecting..."
     minDelayFinished.value = true;
   }, 1000);
 
@@ -198,9 +341,7 @@ onMounted(async () => {
   await setupConnection({
     url: runtimeConfig.public.signalingUrl,
     info,
-    onPin: async () => {
-      return prompt(t("index.enterPin"));
-    },
+    onPin: requestTransferPin,
   });
 });
 </script>
@@ -213,5 +354,13 @@ onMounted(async () => {
   to {
     transform: rotate(360deg);
   }
+}
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -29,6 +29,16 @@ export type FileState = {
   error?: string;
 };
 
+export type ToastMessage = {
+  id: number;
+  message: string;
+  type: "success" | "error" | "info";
+};
+
+export type ConnectionStatus = "connected" | "reconnecting" | "disconnected";
+
+let toastIdCounter = 0;
+
 export const store = reactive({
   // Whether the connection loop has started
   _loopStarted: false,
@@ -53,6 +63,12 @@ export const store = reactive({
   // List of peers connected to the same room
   peers: [] as ClientInfo[],
 
+  // Connection status
+  connectionStatus: "disconnected" as ConnectionStatus,
+
+  // Toast notifications
+  toasts: [] as ToastMessage[],
+
   // Current session information
   session: {
     state: SessionState.idle,
@@ -61,6 +77,32 @@ export const store = reactive({
     fileState: {} as Record<string, FileState>,
   },
 });
+
+export function showToast(message: string, type: ToastMessage["type"] = "info") {
+  const id = ++toastIdCounter;
+  store.toasts.push({ id, message, type });
+  setTimeout(() => dismissToast(id), 4000);
+}
+
+export function dismissToast(id: number) {
+  store.toasts = store.toasts.filter((t) => t.id !== id);
+}
+
+function showBrowserNotification(title: string, body: string) {
+  if (typeof window === "undefined") return;
+  if (document.visibilityState === "visible") return;
+  if ("Notification" in window && Notification.permission === "granted") {
+    new Notification(title, { body, icon: "/apple-touch-icon.png" });
+  }
+}
+
+export function requestNotificationPermission() {
+  if (typeof window !== "undefined" && "Notification" in window) {
+    if (Notification.permission === "default") {
+      Notification.requestPermission();
+    }
+  }
+}
 
 export async function setupConnection({
   url,
@@ -82,6 +124,7 @@ export async function setupConnection({
 async function connectionLoop(url: string) {
   while (true) {
     try {
+      store.connectionStatus = "reconnecting";
       store.signaling = await SignalingConnection.connect({
         url: url,
         info: store._proposingClient!,
@@ -90,6 +133,7 @@ async function connectionLoop(url: string) {
             case "HELLO":
               store.client = data.client;
               store.peers = data.peers;
+              store.connectionStatus = "connected";
               break;
             case "JOIN":
               store.peers = [...store.peers, data.peer];
@@ -120,13 +164,15 @@ async function connectionLoop(url: string) {
           store.signaling = null;
           store.client = null;
           store.peers = [];
+          store.connectionStatus = "disconnected";
         },
       });
 
       await store.signaling.waitUntilClose();
     } catch (error) {
+      store.connectionStatus = "reconnecting";
       console.log("Retrying connection in 5 seconds...");
-      await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait before retrying
+      await new Promise((resolve) => setTimeout(resolve, 5000));
     }
   }
 }
@@ -192,6 +238,10 @@ export async function startSendSession({
       },
       onFileProgress: onFileProgress,
     });
+    showToast("Transfer complete!", "success");
+    showBrowserNotification("LocalSend", "Files sent successfully!");
+  } catch (error) {
+    showToast("Transfer failed", "error");
   } finally {
     store.session.state = SessionState.idle;
   }
@@ -250,6 +300,10 @@ export async function acceptOffer({
       },
       onFileProgress: onFileProgress,
     });
+    showToast("Files received!", "success");
+    showBrowserNotification("LocalSend", "Files received successfully!");
+  } catch (error) {
+    showToast("Receiving failed", "error");
   } finally {
     store.session.state = SessionState.idle;
   }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -20,7 +20,24 @@
     "enterPin": "Enter PIN",
     "progress": {
       "titleSending": "Sending files...",
-      "titleReceiving": "Receiving files..."
+      "titleReceiving": "Receiving files...",
+      "total": "Total",
+      "files": "Files",
+      "transferComplete": "Transfer complete!",
+      "transferFailed": "Transfer failed"
+    },
+    "connection": {
+      "connected": "Connected",
+      "reconnecting": "Reconnecting...",
+      "disconnected": "Disconnected"
+    },
+    "dragDrop": {
+      "hint": "Drop files here to send",
+      "noPeer": "No device available to send files"
+    },
+    "dialog": {
+      "confirm": "OK",
+      "cancel": "Cancel"
     }
   }
 }


### PR DESCRIPTION
## Summary

Improve the LocalSend Web UX with 4 new features: drag-and-drop file upload, toast notifications, connection status indicator, and custom input dialogs.

## Changes

### 1. Drag & Drop File Upload
- Drop files directly onto the page to send them to the first available peer
- Full-screen overlay with upload icon shown while dragging files
- Error toast shown if no peers are available

### 2. Toast Notification System
**New component: `Toast.vue`**
- Auto-dismissing toast notifications (4s) for success/error/info messages
- Slide-in animation from the right
- Shown after file transfer completes or fails
- Browser `Notification` API used when the tab is in the background

### 3. Connection Status Indicator
- Live status dot in the header: 🟢 Connected / 🟡 Reconnecting / 🔴 Disconnected
- Status text shown on larger screens
- Updates automatically during WebSocket connect/disconnect/retry cycles

### 4. Custom Input Dialogs
**New component: `InputDialog.vue`**
- Replaces all native `prompt()` calls with styled modal dialogs
- Used for entering alias name, PIN, and transfer PIN
- Supports keyboard shortcuts (Enter to confirm), auto-focus, and text selection
- Consistent dark mode styling

### Additional Improvements
- **Dark mode support for `Dialog.vue`** — Added `dark:bg-gray-800 dark:text-white` classes
- **i18n for `SessionDialog.vue`** — Replaced hardcoded "Total:" and "Files:" with `t()` calls
- **New i18n keys** added to `en.json` for all new UI elements

## Files Changed

| File | Change |
|---|---|
| `app/components/Toast.vue` | **[NEW]** Toast notification component |
| `app/components/dialog/InputDialog.vue` | **[NEW]** Reusable input modal dialog |
| `app/components/dialog/Dialog.vue` | **[MODIFIED]** Dark mode support |
| `app/components/dialog/SessionDialog.vue` | **[MODIFIED]** i18n for hardcoded strings |
| `app/pages/index.vue` | **[MODIFIED]** Drag & drop, connection status, custom modals |
| `app/services/store.ts` | **[MODIFIED]** Toast system, connection status, browser notifications |
| `i18n/locales/en.json` | **[MODIFIED]** New translation keys |

## Testing
- Drag and drop: verified overlay shows on dragover, hides on dragleave/drop
- Toast: verified success/error toasts appear after session state changes
- Connection status: verified dot color updates during connect/disconnect lifecycle
- Input dialogs: verified alias, PIN, and transfer PIN use custom modals instead of `prompt()`
