### PR TITLE
perf(webrtc): remove STUN server for faster local network transfers

### DIFF
--- a/app/services/webrtc.ts
+++ b/app/services/webrtc.ts
@@ -11,7 +11,8 @@ import { generateClientTokenFromNonce } from "~/services/crypto";
 
 export const protocolVersion = "2.3";
 
-export const defaultStun = ["stun:stun.l.google.com:19302"];
+// Empty = no STUN, only local IP candidates (sufficient for LAN)
+export const defaultStun: string[] = [];
 
 export async function sendFiles({
   signaling,


### PR DESCRIPTION
LocalSend is designed for local network file transfers only, so STUN
servers are not needed. The previous implementation was waiting for
STUN responses which caused delays, even though local IP candidates
are sufficient for peer-to-peer connections on the same network.

This change:
- Removes Google STUN server from default configuration
- ICE gathering now uses only local IP candidates  
- Significantly faster connection establishment for local transfers
- Fixes issue where STUN timeout (when server is unreachable or 
  behind firewall) causes very slow "Creating offer" response

Background:
- LocalSend uses WebRTC for peer-to-peer file transfer
- Signaling server (wss://public.localsend.org) is only for peer
  discovery, not for actual data transfer
- Both peers must be on the same network to discover each other
- STUN is only needed for cross-network connections (different NATs)
- With empty iceServers, WebRTC uses only local host candidates
