### PR TITLE
feat: Implement PIN management using session storage

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -83,6 +83,7 @@ import {
   startSendSession,
   store,
   updateAliasState,
+  setPinState,
 } from "@/services/store";
 import { getAgentInfoString } from "~/utils/userAgent";
 import { protocolVersion } from "~/services/webrtc";
@@ -108,6 +109,20 @@ const { t } = useI18n();
 
 const { open: openFileDialog, onChange } = useFileDialog();
 
+const minDelayFinished = ref(false);
+
+const webCryptoSupported = ref(true);
+
+const targetId = ref("");
+
+const promptAndSavePin = async (): Promise<string | null> => {
+  const pin = prompt(t("index.enterPin"));
+  if (pin !== null) {
+    setPinState(pin);
+  }
+  return pin;
+};
+
 onChange(async (files) => {
   if (!files) return;
 
@@ -118,16 +133,9 @@ onChange(async (files) => {
   await startSendSession({
     files,
     targetId: targetId.value,
-    onPin: async () => {
-      return prompt(t("index.enterPin"));
-    },
+    onPin: promptAndSavePin,
   });
 });
-
-const minDelayFinished = ref(false);
-const webCryptoSupported = ref(true);
-
-const targetId = ref("");
 
 const selectPeer = (id: string) => {
   targetId.value = id;
@@ -160,7 +168,7 @@ const updateAlias = async () => {
 const updatePIN = async () => {
   const pin = prompt(t("index.enterPin"));
   if (typeof pin === "string") {
-    store.pin = pin ? pin : null;
+    setPinState(pin ? pin : null);
   }
 };
 
@@ -198,9 +206,7 @@ onMounted(async () => {
   await setupConnection({
     url: runtimeConfig.public.signalingUrl,
     info,
-    onPin: async () => {
-      return prompt(t("index.enterPin"));
-    },
+    onPin: promptAndSavePin,
   });
 });
 </script>

--- a/app/services/store.ts
+++ b/app/services/store.ts
@@ -42,8 +42,7 @@ export const store = reactive({
   key: null as CryptoKeyPair | null,
 
   /// PIN code used before receiving or sending files
-  pin: null as string | null,
-
+  pin: sessionStorage.getItem("transfer_pin") ?? null,
   // Signaling connection to the server
   signaling: null as SignalingConnection | null,
 
@@ -129,6 +128,20 @@ async function connectionLoop(url: string) {
       await new Promise((resolve) => setTimeout(resolve, 5000)); // Wait before retrying
     }
   }
+}
+watch(
+  () => store.pin,
+  (newPin) => {
+    if (newPin) {
+      sessionStorage.setItem("transfer_pin", newPin);
+    } else {
+      sessionStorage.removeItem("transfer_pin");
+    }
+  },
+  { immediate: false }
+);
+export function setPinState(pin: string | null) {
+  store.pin = (pin && pin.trim() !== "") ? pin : null;
 }
 
 export function updateAliasState(alias: string) {


### PR DESCRIPTION
1. Check pin in session storage on page load, added watcher to change pin the moment it changes
2. export setPinState to index page 
3.  implement async function promptAndSavePin to validate(if not null) and store the pin and reuse it on to the page
4. Move states(minDelayFinished,webCryptoSupported and targetId) to a little top for better consistency