### PR TITLE
feat: add Web Share Target support

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -106,6 +106,8 @@ const runtimeConfig = useRuntimeConfig();
 
 const { t } = useI18n();
 
+const sharedFiles = ref<File[]>([]);
+
 const { open: openFileDialog, onChange } = useFileDialog();
 
 onChange(async (files) => {
@@ -131,7 +133,20 @@ const targetId = ref("");
 
 const selectPeer = (id: string) => {
   targetId.value = id;
-  openFileDialog();
+
+  if (sharedFiles.value.length > 0) {
+    // Came from share target — use already received files
+    const files = sharedFiles.value;
+    sharedFiles.value = [];
+    startSendSession({
+      files: files as unknown as FileList,
+      targetId: id,
+      onPin: async () => prompt(t("index.enterPin")),
+    });
+  } else {
+    // Normal flow — open file dialog
+    openFileDialog();
+  }
 };
 
 const updateAlias = async () => {
@@ -201,6 +216,13 @@ onMounted(async () => {
     onPin: async () => {
       return prompt(t("index.enterPin"));
     },
+  });
+
+  // Listen for shared files from the Web Share Target SW handler
+  navigator.serviceWorker.addEventListener("message", (event) => {
+    if (event.data?.type === "share-target") {
+      sharedFiles.value = event.data.files ?? [];
+    }
   });
 });
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -146,8 +146,25 @@ export default defineNuxtConfig({
           purpose: "any maskable",
         },
       ],
+      share_target: {
+        action: "/",
+        method: "POST",
+        enctype: "multipart/form-data",
+        params: {
+          title: "title",
+          text: "text",
+          url: "url",
+          files: [
+            {
+              name: "files",
+              accept: ["*/*"],
+            },
+          ],
+        },
+      },
     },
     workbox: {
+      importScripts: ["sw-share-target.js"],
       globPatterns: ["/", "**/*.{js,css,html,png,svg,ico}"],
       navigateFallback: "/",
       runtimeCaching: [

--- a/public/sw-share-target.js
+++ b/public/sw-share-target.js
@@ -1,0 +1,41 @@
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  if (url.pathname !== '/' || event.request.method !== 'POST') return
+
+  event.respondWith(
+    (async () => {
+      const formData = await event.request.formData()
+      const files = formData.getAll('files')
+      const title = formData.get('title') ?? ''
+      const text = formData.get('text') ?? ''
+      const sharedUrl = formData.get('url') ?? ''
+
+      const payload = {
+        type: 'share-target',
+        files,
+        title,
+        text,
+        url: sharedUrl,
+      }
+
+      // Redirect first, then postMessage after client loads
+      const response = Response.redirect(self.location.origin + '/', 303)
+
+      event.waitUntil(
+        (async () => {
+          // Wait for the client to be ready after redirect
+          await new Promise(resolve => setTimeout(resolve, 1000))
+          const allClients = await self.clients.matchAll({
+            type: 'window',
+            includeUncontrolled: true,
+          })
+          for (const client of allClients) {
+            client.postMessage(payload)
+          }
+        })()
+      )
+
+      return response
+    })()
+  )
+})


### PR DESCRIPTION
## What
Adds Web Share Target API support, allowing the installed PWA to appear 
in the native share dialog on Android and other supported platforms.

## How it works
- Added `share_target` to the PWA manifest pointing to `/` via POST
- Added `public/sw-share-target.js` which intercepts the POST in the 
  Service Worker, extracts the shared files and forwards them to the 
  app via `postMessage`
- Updated `index.vue` to listen for the `postMessage` and trigger 
  `startSendSession` when the user selects a peer

## Usage
1. Install the PWA on Android
2. Share any file from any app
3. Select LocalSend Web from the share dialog
4. Select the peer to send to

## Notes
- Requires the PWA to be installed
- Works with any file type (`*/*`)
- If multiple peers are available, the user selects which one to send to