### PR TITLE
feat(i18n): add Hindi (HI) and Gujarati (GU) language support

### DIFF
--- a/i18n/locales/gu.json
+++ b/i18n/locales/gu.json
@@ -1,0 +1,26 @@
+{
+  "index": {
+    "seo": {
+      "title": "LocalSend વેબ",
+      "description": "તમારા બ્રાઉઝર અને LocalSend ચલાવતા અન્ય ઉપકરણો વચ્ચે ફાઇલો શેર કરો."
+    },
+    "connecting": "કનેક્ટ થઈ રહ્યું છે...",
+    "webCryptoNotSupported": "તમારું બ્રાઉઝર LocalSend ને સપોર્ટ કરતું નથી: Web Crypto API જરૂરી છે.",
+    "empty": {
+      "title": "બીજા ઉપકરણ પર LocalSend ખોલો.",
+      "deviceHint": "આ સાઇટને બીજા બ્રાઉઝર અથવા નેટિવ સંસ્કરણ (v1.18.0 અથવા નવું) માં ખોલો.",
+      "lanHint": "ફક્ત સમાન નેટવર્કમાંના ઉપકરણો જ બતાવવામાં આવે છે."
+    },
+    "you": "તમે છો:",
+    "pin": {
+      "label": "PIN: ",
+      "none": "કોઈ નહીં"
+    },
+    "enterAlias": "નામ દાખલ કરો",
+    "enterPin": "PIN દાખલ કરો",
+    "progress": {
+      "titleSending": "ફાઇલો મોકલાઈ રહી છે...",
+      "titleReceiving": "ફાઇલો પ્રાપ્ત થઈ રહી છે..."
+    }
+  }
+}

--- a/i18n/locales/hi.json
+++ b/i18n/locales/hi.json
@@ -1,0 +1,26 @@
+{
+  "index": {
+    "seo": {
+      "title": "LocalSend वेब",
+      "description": "अपने ब्राउज़र और LocalSend चला रहे अन्य डिवाइसों के बीच फ़ाइलें साझा करें।"
+    },
+    "connecting": "कनेक्ट हो रहा है...",
+    "webCryptoNotSupported": "आपका ब्राउज़र LocalSend का समर्थन नहीं करता: Web Crypto API आवश्यक है।",
+    "empty": {
+      "title": "किसी अन्य डिवाइस पर LocalSend खोलें।",
+      "deviceHint": "इस साइट को किसी अन्य ब्राउज़र या नेटिव संस्करण (v1.18.0 या नया) में खोलें।",
+      "lanHint": "केवल समान नेटवर्क के डिवाइस ही दिखाए जाते हैं।"
+    },
+    "you": "आप हैं:",
+    "pin": {
+      "label": "PIN: ",
+      "none": "कोई नहीं"
+    },
+    "enterAlias": "नाम दर्ज करें",
+    "enterPin": "PIN दर्ज करें",
+    "progress": {
+      "titleSending": "फ़ाइलें भेजी जा रही हैं...",
+      "titleReceiving": "फ़ाइलें प्राप्त की जा रही हैं..."
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -60,6 +60,18 @@ export default defineNuxtConfig({
         name: "فارسی",
       },
       {
+        code: "gu",
+        language: "gu-IN",
+        file: "gu.json",
+        name: "ગુજરાતી",
+      },
+      {
+        code: "hi",
+        language: "hi-IN",
+        file: "hi.json",
+        name: "हिन्दी",
+      },
+      {
         code: "hu",
         language: "hu-HU",
         file: "hu.json",


### PR DESCRIPTION
## Summary

Adds Hindi (hi) and Gujarati (gu) language support to the LocalSend Web App.

## Changes

### 1. New files

* `i18n/locales/hi.json`
* `i18n/locales/gu.json`

Complete Hindi and Gujarati translations of all strings in the web app, including:

* SEO title and description
* Connection status messages
* Empty state messages (device hint, LAN hint)
* User identity labels
* PIN labels
* Alias input placeholder
* File transfer progress messages

### 2. Modified: `nuxt.config.ts`

Registered the Hindi and Gujarati locales in the i18n configuration:

#### Hindi

* Code: `hi`
* Language: `hi-IN`
* Name: `हिन्दी`

#### Gujarati

* Code: `gu`
* Language: `gu-IN`
* Name: `ગુજરાતી`

## Notes

* All strings from `en.json` have been translated.
* Translation files have been validated for correctness.
